### PR TITLE
Fix bug with GameController level initialisation

### DIFF
--- a/LifeOfWilbur/Assets/Scripts/GameController.cs
+++ b/LifeOfWilbur/Assets/Scripts/GameController.cs
@@ -63,6 +63,10 @@ public class GameController : MonoBehaviour, ILevelController
             _movingToNextLevel = false;
             _resettingLevel = false;
             StartCoroutine(GetComponent<TransitionController>().FadeInFromBlack());
+            if(GetComponent<TimeTravelController>().enabled)
+            {
+                GetComponent<TimeTravelController>().RegisterGameObjects();
+            }
             GetComponent<TimeTravelController>().enabled = true;
             GetComponent<TransitionController>().enabled = true;
         }


### PR DESCRIPTION
Add a call to RegisterGameObjects if the component is already enabled.
If the component was disabled, the method is called when the component
is enabled, but not if it was enabled already.