### PR TITLE
Call RegisterGameObjects one frame after enable

### DIFF
--- a/LifeOfWilbur/Assets/Scripts/TimeTravel/TimeTravelController.cs
+++ b/LifeOfWilbur/Assets/Scripts/TimeTravel/TimeTravelController.cs
@@ -72,6 +72,12 @@ public class TimeTravelController : MonoBehaviour
 
     private void OnEnable()
     {
+        StartCoroutine(RegisterGameObjectsSoon());
+    }
+
+    private IEnumerator RegisterGameObjectsSoon()
+    {
+        yield return null;
         RegisterGameObjects();
     }
 


### PR DESCRIPTION
To fix build.

This is caused by a condition where RegisterGameObjects is called before
all assets are loaded. This means that some of the assets don't work for
the time travel.

Fixed by making OnEnable call a new RegisterGameObjectsSoon coroutine
which calls RegisterGameObjects after one frame.